### PR TITLE
Force Dynamic Rendering for database queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,32 @@ psql -U <user name> <database name>
 ```bash
 sudo -u <user name> psql -U <user name> <database name>
 ```
+
+# API DESIGN
+
+```ts
+type Animal = {
+  id: number;
+  type: string;
+  firstName: string;
+  accessory: string | null;
+};
+
+type Error = {
+  message: string;
+};
+```
+
+```txt
+/
+ - GET => endpoints[]
+
+/animals
+ - GET =>       animal[]
+ - POST =>      animal   | error
+
+/animals/:id
+ - PUT =>       animal   | error
+ - DELETE =>    animal   | error
+ - GET =>       animal   | error
+```

--- a/app/animal-management-naive-dont-copy/read/page.js
+++ b/app/animal-management-naive-dont-copy/read/page.js
@@ -7,8 +7,6 @@ export const metadata = {
   description: 'My favorite animals',
 };
 
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalsPage() {
   const animals = await getAnimals();
 

--- a/app/animals-admin/AnimalsForm.module.scss
+++ b/app/animals-admin/AnimalsForm.module.scss
@@ -1,0 +1,20 @@
+.button {
+  border: 1px solid;
+  cursor: pointer;
+  background-color: white;
+  color: rgb(0, 31, 57);
+  border-radius: 5px;
+
+  &:hover {
+    background-color: rgb(0, 31, 57);
+    color: white;
+  }
+}
+
+.inputDiv {
+  input {
+    background-color: rgb(248, 54, 112);
+    border-radius: 5px;
+    border: none;
+  }
+}

--- a/app/animals-admin/AnimalsForm.tsx
+++ b/app/animals-admin/AnimalsForm.tsx
@@ -1,0 +1,182 @@
+'use client';
+import { useState } from 'react';
+import { Animal } from '../../migrations/1684915044-createTableAnimals';
+import styles from './AnimalsForm.module.scss';
+
+type Props = {
+  animals: Animal[];
+};
+
+export default function AnimalsForm({ animals }: Props) {
+  const [animalList, setAnimalList] = useState(animals);
+  const [firstNameInput, setFirstNameInput] = useState('');
+  const [typeInput, setTypeInput] = useState('');
+  const [accessoryInput, setAccessoryInput] = useState('');
+  const [onEditId, setOnEditId] = useState<number>();
+
+  // only for on edit inputs
+  const [onEditFirstNameInput, setOnEditFirstNameInput] = useState('');
+  const [onEditTypeInput, setOnEditTypeInput] = useState('');
+  const [onEditAccessoryInput, setOnEditAccessoryInput] = useState('');
+
+  async function createAnimal() {
+    const response = await fetch('/api/animals', {
+      method: 'POST',
+      body: JSON.stringify({
+        firstName: firstNameInput,
+        type: typeInput,
+        accessory: accessoryInput,
+      }),
+    });
+
+    const data = await response.json();
+
+    setAnimalList([...animalList, data.animal]);
+  }
+
+  async function deleteAnimalById(id: number) {
+    const response = await fetch(`/api/animals/${id}`, {
+      method: 'DELETE',
+    });
+
+    const data = await response.json();
+
+    setAnimalList(animalList.filter((animal) => animal.id !== data.animal.id));
+  }
+
+  async function updateAnimalById(id: number) {
+    const response = await fetch(`/api/animals/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        firstName: onEditFirstNameInput,
+        type: onEditTypeInput,
+        accessory: onEditAccessoryInput,
+      }),
+    });
+
+    const data = await response.json();
+
+    setAnimalList(
+      animalList.map((animal) => {
+        if (animal.id === data.animal.id) {
+          return data.animal;
+        }
+        return animal;
+      }),
+    );
+  }
+
+  return (
+    <div className={styles.inputDiv}>
+      <label>
+        <input
+          value={firstNameInput}
+          onChange={(event) => setFirstNameInput(event.currentTarget.value)}
+        />
+        First Name
+      </label>
+      <br />
+      <label>
+        <input
+          value={typeInput}
+          onChange={(event) => setTypeInput(event.currentTarget.value)}
+        />
+        Type
+      </label>
+      <br />
+      <label>
+        <input
+          value={accessoryInput}
+          onChange={(event) => setAccessoryInput(event.currentTarget.value)}
+        />
+        Accessory
+      </label>
+      <br />
+      <button
+        className={styles.button}
+        onClick={async () => await createAnimal()}
+      >
+        create +
+      </button>
+
+      {animalList.map((animal) => {
+        return (
+          <div key={`animal-inputs-${animal.id}`} className={styles.inputDiv}>
+            <br />
+            <label>
+              <input
+                value={
+                  animal.id !== onEditId
+                    ? animal.firstName
+                    : onEditFirstNameInput
+                }
+                onChange={(event) =>
+                  setOnEditFirstNameInput(event.currentTarget.value)
+                }
+                disabled={animal.id !== onEditId}
+              />
+              First Name
+            </label>
+            <br />
+            <label>
+              <input
+                value={animal.id !== onEditId ? animal.type : onEditTypeInput}
+                onChange={(event) =>
+                  setOnEditTypeInput(event.currentTarget.value)
+                }
+                disabled={animal.id !== onEditId}
+              />
+              Type
+            </label>
+            <br />
+            <label>
+              <input
+                value={
+                  animal.id !== onEditId
+                    ? animal.accessory || ''
+                    : onEditAccessoryInput
+                }
+                onChange={(event) =>
+                  setOnEditAccessoryInput(event.currentTarget.value)
+                }
+                disabled={animal.id !== onEditId}
+              />
+              Accessory
+            </label>
+            <br />
+            {animal.id === onEditId ? (
+              <button
+                className={styles.button}
+                onClick={async () => {
+                  setOnEditId(undefined);
+                  await updateAnimalById(animal.id);
+                }}
+              >
+                save
+              </button>
+            ) : (
+              <button
+                className={styles.button}
+                onClick={() => {
+                  setOnEditId(animal.id);
+                  setOnEditFirstNameInput(animal.firstName);
+                  setOnEditTypeInput(animal.type);
+                  setOnEditAccessoryInput(animal.accessory || '');
+                }}
+              >
+                edit
+              </button>
+            )}
+            <button
+              className={styles.button}
+              onClick={async () => await deleteAnimalById(animal.id)}
+            >
+              x
+            </button>
+            <br />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/animals-admin/page.tsx
+++ b/app/animals-admin/page.tsx
@@ -1,0 +1,7 @@
+import { getAnimals } from '../../database/animals';
+import AnimalsForm from './AnimalsForm';
+
+export default async function AnimalsAdminPage() {
+  const animals = await getAnimals();
+  return <AnimalsForm animals={animals} />;
+}

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -7,8 +7,6 @@ export const metadata = {
   description: 'My favorite animals',
 };
 
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalsPage() {
   const animals = await getAnimals();
 

--- a/app/animals/paginated/Dashboard.module.scss
+++ b/app/animals/paginated/Dashboard.module.scss
@@ -1,0 +1,12 @@
+.button {
+  border: 1px solid;
+  cursor: pointer;
+  background-color: white;
+  color: rgb(0, 31, 57);
+  border-radius: 5px;
+
+  &:hover {
+    background-color: rgb(0, 31, 57);
+    color: white;
+  }
+}

--- a/app/animals/paginated/Dashboard.tsx
+++ b/app/animals/paginated/Dashboard.tsx
@@ -1,0 +1,45 @@
+'use client';
+// import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Animal } from '../../../migrations/1684915044-createTableAnimals';
+import styles from './Dashboard.module.scss';
+
+type Props = {
+  animals: Animal[];
+};
+
+export default function Dashboard(props: Props) {
+  const [animals, setAnimals] = useState<Animal[]>(props.animals);
+
+  return (
+    <div>
+      <div>
+        {animals.map((animal) => (
+          <div key={`animal-${animal.id}`}>
+            {animal.firstName}
+            {animal.type}
+            {animal.accessory}
+          </div>
+        ))}
+      </div>
+      <button
+        className={styles.button}
+        onClick={async () => {
+          // how many animals are in the screen right now
+          const animalCount = animals.length;
+
+          const response = await fetch(
+            `/api/animals?limit=3&offset=${animalCount}`,
+          );
+
+          const data = await response.json();
+
+          setAnimals([...animals, ...data.animals]);
+          // get 3 new animals
+        }}
+      >
+        show 3 more
+      </button>
+    </div>
+  );
+}

--- a/app/animals/paginated/page.tsx
+++ b/app/animals/paginated/page.tsx
@@ -1,0 +1,8 @@
+import { getAnimalsWithLimitAndOffset } from '../../../database/animals';
+import Dashboard from './Dashboard';
+
+export default async function AnimalAdminPage() {
+  const animals = await getAnimalsWithLimitAndOffset(2, 0);
+
+  return <Dashboard animals={animals} />;
+}

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  deleteAnimalById,
+  getAnimalById,
+  updateAnimalById,
+} from '../../../../database/animals';
+import { Animal, Error } from '../route';
+
+type AnimalResponseBodyGet = { animal: Animal } | Error;
+type AnimalResponseBodyDelete = { animal: Animal } | Error;
+type AnimalResponseBodyPut = { animal: Animal } | Error;
+
+const animalSchema = z.object({
+  firstName: z.string(),
+  type: z.string(),
+  accessory: z.string().optional(),
+});
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Record<string, string | string[]> },
+): Promise<NextResponse<AnimalResponseBodyGet>> {
+  const animalId = Number(params.animalId);
+
+  if (!animalId) {
+    return NextResponse.json(
+      {
+        error: 'Animal id is not valid',
+      },
+      { status: 400 },
+    );
+  }
+  // query the database to get all the animals
+  const animal = await getAnimalById(animalId);
+
+  if (!animal) {
+    return NextResponse.json(
+      {
+        error: 'Animal Not Found',
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ animal: animal });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Record<string, string | string[]> },
+): Promise<NextResponse<AnimalResponseBodyDelete>> {
+  const animalId = Number(params.animalId);
+
+  if (!animalId) {
+    return NextResponse.json(
+      {
+        error: 'Animal id is not valid',
+      },
+      { status: 400 },
+    );
+  }
+  // query the database to get all the animals
+  const animal = await deleteAnimalById(animalId);
+
+  if (!animal) {
+    return NextResponse.json(
+      {
+        error: 'Animal Not Found',
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ animal: animal });
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Record<string, string | string[]> },
+): Promise<NextResponse<AnimalResponseBodyPut>> {
+  const animalId = Number(params.animalId);
+  const body = await request.json();
+
+  if (!animalId) {
+    return NextResponse.json(
+      {
+        error: 'Animal id is not valid',
+      },
+      { status: 400 },
+    );
+  }
+
+  // zod please verify the body matches my schema
+  const result = animalSchema.safeParse(body);
+
+  if (!result.success) {
+    // zod send you details about the error
+    // console.log(result.error);
+    return NextResponse.json(
+      {
+        error: 'The data is incomplete',
+      },
+      { status: 400 },
+    );
+  }
+  // query the database to update the animal
+  const animal = await updateAnimalById(
+    animalId,
+    result.data.firstName,
+    result.data.type,
+    result.data.accessory,
+  );
+
+  if (!animal) {
+    return NextResponse.json(
+      {
+        error: 'Animal Not Found',
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    animal: animal,
+  });
+}

--- a/app/api/animals/route.ts
+++ b/app/api/animals/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  createAnimal,
+  getAnimals,
+  getAnimalsWithLimitAndOffset,
+} from '../../../database/animals';
+
+export type Animal = {
+  id: number;
+  firstName: string;
+  type: string;
+  accessory: string | null;
+};
+
+export type Error = {
+  error: string;
+};
+
+type AnimalsResponseBodyGet = { animals: Animal[] } | Error;
+type AnimalsResponseBodyPost = { animal: Animal } | Error;
+
+const animalSchema = z.object({
+  firstName: z.string(),
+  type: z.string(),
+  accessory: z.string().optional(),
+});
+
+export async function GET(
+  request: NextRequest,
+): Promise<NextResponse<AnimalsResponseBodyGet>> {
+  const { searchParams } = new URL(request.url);
+
+  const limit = Number(searchParams.get('limit'));
+  const offset = Number(searchParams.get('offset'));
+
+  console.log(limit, offset);
+
+  if (!limit || !offset) {
+    return NextResponse.json(
+      {
+        error: 'Limit and Offset need to be passed as params',
+      },
+      { status: 400 },
+    );
+  }
+
+  // query the database to get all the animals
+  const animals = await getAnimalsWithLimitAndOffset(limit, offset);
+
+  return NextResponse.json({ animals: animals });
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<AnimalsResponseBodyPost>> {
+  const body = await request.json();
+
+  // zod please verify the body matches my schema
+  const result = animalSchema.safeParse(body);
+
+  if (!result.success) {
+    // zod send you details about the error
+    // console.log(result.error);
+    return NextResponse.json(
+      {
+        error: 'The data is incomplete',
+      },
+      { status: 400 },
+    );
+  }
+  // query the database to get all the animals
+  const animal = await createAnimal(
+    result.data.firstName,
+    result.data.type,
+    result.data.accessory,
+  );
+
+  if (!animal) {
+    // zod send you details about the error
+    // console.log(result.error);
+    return NextResponse.json(
+      {
+        error: 'Error creating the new animal',
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    animal: animal,
+  });
+}

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export function GET(): NextResponse<{ animals: string }> {
+  return NextResponse.json({ animals: '/api/animals' });
+}

--- a/app/fruits/[fruitId]/page.tsx
+++ b/app/fruits/[fruitId]/page.tsx
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getFruitById } from '../../../database/fruits';
 import { getCookie } from '../../../util/cookies';
@@ -15,8 +14,6 @@ export type CookieCommentItem = {
 };
 
 export default function FruitPage(props: Props) {
-  const x = headers();
-  x.forEach((a) => console.log(a));
   const fruit = getFruitById(Number(props.params.fruitId));
 
   if (!fruit) {

--- a/app/fruits/[fruitId]/page.tsx
+++ b/app/fruits/[fruitId]/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getFruitById } from '../../../database/fruits';
 import { getCookie } from '../../../util/cookies';
@@ -14,6 +15,8 @@ export type CookieCommentItem = {
 };
 
 export default function FruitPage(props: Props) {
+  const x = headers();
+  x.forEach((a) => console.log(a));
   const fruit = getFruitById(Number(props.params.fruitId));
 
   if (!fruit) {

--- a/app/layout.js
+++ b/app/layout.js
@@ -22,6 +22,8 @@ export default function RootLayout({ children }) {
         <nav className={style.navigator}>
           <Link href="/">home</Link> <Link href="/animals">animals</Link>{' '}
           <Link href="/fruits">fruits</Link>
+          <Link href="/animals-admin">admin</Link>
+          <Link href="/animals/paginated">paginated</Link>
           {Math.floor(Math.random() * 10)}
         </nav>
         {children}

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers';
 import { cache } from 'react';
 import { Animal } from '../migrations/1684915044-createTableAnimals';
 import {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import { cache } from 'react';
 import { Animal } from '../migrations/1684915044-createTableAnimals';
 import {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -31,8 +31,25 @@ export const getAnimals = cache(async () => {
   const animals = await sql<Animal[]>`
     SELECT * FROM animals
  `;
-  return animals;
+  return [...animals];
 });
+
+
+export const getAnimalsWithLimitAndOffset = cache(
+  async (limit: number, offset: number) => {
+    const animals = await sql<Animal[]>`
+      SELECT
+        *
+      FROM
+        animals
+      LIMIT ${limit}
+      OFFSET ${offset}
+    `;
+
+    return animals;
+  },
+);
+
 
 export const getAnimalById = cache(async (id: number) => {
   const [animal] = await sql<Animal[]>`
@@ -47,12 +64,12 @@ export const getAnimalById = cache(async (id: number) => {
 });
 
 export const createAnimal = cache(
-  async (firstName: string, type: string, accessory: string) => {
+  async (firstName: string, type: string, accessory?: string) => {
     const [animal] = await sql<Animal[]>`
       INSERT INTO animals
         (first_name, type, accessory)
       VALUES
-        (${firstName}, ${type}, ${accessory})
+        (${firstName}, ${type}, ${accessory || null})
       RETURNING *
     `;
 
@@ -61,13 +78,13 @@ export const createAnimal = cache(
 );
 
 export const updateAnimalById = cache(
-  async (id: number, firstName: string, type: string, accessory: string) => {
+  async (id: number, firstName: string, type: string, accessory?: string) => {
     const [animal] = await sql<Animal[]>`
       UPDATE animals
       SET
         first_name = ${firstName},
         type = ${type},
-        accessory = ${accessory}
+        accessory = ${accessory || null}
       WHERE
         id = ${id}
         RETURNING *

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
+import { headers } from 'next/headers';
 import postgres from 'postgres';
 
 // This loads all environment variables from a .env file
@@ -31,8 +32,12 @@ function connectOneTimeToDatabase() {
       },
     });
   }
-  return globalThis.postgresSqlClient;
+
+  return async (strings: TemplateStringsArray, ...values: any) => {
+    headers();
+    return await globalThis.postgresSqlClient!(strings, ...values);
+  };
 }
 
 // Connect to PostgreSQL
-export const sql = connectOneTimeToDatabase();
+export const sql = connectOneTimeToDatabase() as ReturnType<typeof postgres>;

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -33,9 +33,9 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return async (strings: TemplateStringsArray, ...values: any) => {
+  return (...sqlQuery: [TemplateStringsArray, ...any[]]) => {
     headers();
-    return await globalThis.postgresSqlClient!(strings, ...values);
+    return globalThis.postgresSqlClient!(...sqlQuery);
   };
 }
 

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
 import { headers } from 'next/headers';
-import postgres from 'postgres';
+import postgres, { PendingQuery } from 'postgres';
 
 // This loads all environment variables from a .env file
 // for all code after this line
@@ -33,11 +33,13 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return (...sqlQuery: [TemplateStringsArray, ...any[]]) => {
+  return <T extends (object | undefined)[]>(
+    ...sqlQuery: [TemplateStringsArray, ...any[]]
+  ) => {
     headers();
-    return globalThis.postgresSqlClient!(...sqlQuery);
+    return globalThis.postgresSqlClient!<T>(...sqlQuery);
   };
 }
 
 // Connect to PostgreSQL
-export const sql = connectOneTimeToDatabase() as ReturnType<typeof postgres>;
+export const sql = connectOneTimeToDatabase();

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
 import { headers } from 'next/headers';
-import postgres, { PendingQuery } from 'postgres';
+import postgres from 'postgres';
 
 // This loads all environment variables from a .env file
 // for all code after this line

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -33,12 +33,7 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return <T extends (object | undefined)[]>(
-    ...sqlQuery: [TemplateStringsArray, ...any[]]
-  ) => {
-    headers();
-    return globalThis.postgresSqlClient!<T>(...sqlQuery);
-  };
+  return globalThis.postgresSqlClient;
 }
 
 // Connect to PostgreSQL

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "secure-json-parse": "^2.7.0",
     "server-only": "^0.0.1",
     "sharp": "^0.32.1",
-    "tsm": "^2.3.0"
+    "tsm": "^2.3.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ dependencies:
   tsm:
     specifier: ^2.3.0
     version: 2.3.0
+  zod:
+    specifier: ^3.21.4
+    version: 3.21.4
 
 devDependencies:
   '@jest/globals':


### PR DESCRIPTION
This PR update the `connectOneTimeToDatabase()` function in order to call `headers()` in every call of the sql client. This will prevent Next.js wrongly flag some pages using database queries as static content.

A new [feature request was created](https://github.com/vercel/next.js/discussions/50695#discussion-5258288) to not need to call headers in every sql query