### PR TITLE
Force Dynamic Rendering for database queries

### DIFF
--- a/app/animal-management-naive-dont-copy/read/[animalId]/page.js
+++ b/app/animal-management-naive-dont-copy/read/[animalId]/page.js
@@ -2,8 +2,6 @@ import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { getAnimalById } from '../../../../database/animals';
 
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalPage({ params }) {
   const singleAnimal = await getAnimalById(Number(params.animalId));
 

--- a/app/animal-management-naive-dont-copy/read/page.js
+++ b/app/animal-management-naive-dont-copy/read/page.js
@@ -7,8 +7,6 @@ export const metadata = {
   description: 'My favorite animals',
 };
 
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalsPage() {
   const animals = await getAnimals();
 

--- a/app/animal-management-naive-dont-copy/read/page.js
+++ b/app/animal-management-naive-dont-copy/read/page.js
@@ -7,6 +7,8 @@ export const metadata = {
   description: 'My favorite animals',
 };
 
+export const dynamic = 'force-dynamic';
+
 export default async function AnimalsPage() {
   const animals = await getAnimals();
 

--- a/app/animals-admin/page.tsx
+++ b/app/animals-admin/page.tsx
@@ -1,9 +1,6 @@
 import { getAnimals } from '../../database/animals';
 import AnimalsForm from './AnimalsForm';
 
-// Use 'force-dynamic' on pages using database queries in the server component to prevent your deployment to fail.
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalsAdminPage() {
   const animals = await getAnimals();
   return <AnimalsForm animals={animals} />;

--- a/app/animals/[animalId]/page.tsx
+++ b/app/animals/[animalId]/page.tsx
@@ -2,8 +2,6 @@ import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { getAnimalById } from '../../../database/animals';
 
-export const dynamic = 'force-dynamic';
-
 type Props = {
   params: {
     animalId: string;

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -7,8 +7,6 @@ export const metadata = {
   description: 'My favorite animals',
 };
 
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalsPage() {
   const animals = await getAnimals();
 

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -7,6 +7,8 @@ export const metadata = {
   description: 'My favorite animals',
 };
 
+export const dynamic = 'force-dynamic';
+
 export default async function AnimalsPage() {
   const animals = await getAnimals();
 

--- a/app/animals/paginated/page.tsx
+++ b/app/animals/paginated/page.tsx
@@ -1,9 +1,6 @@
 import { getAnimalsWithLimitAndOffset } from '../../../database/animals';
 import Dashboard from './Dashboard';
 
-// Use 'force-dynamic' on pages using database queries in the server component to prevent your deployment to fail.
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalAdminPage() {
   const animals = await getAnimalsWithLimitAndOffset(2, 0);
 

--- a/app/animals/with-foods/[animalId]/page.js
+++ b/app/animals/with-foods/[animalId]/page.js
@@ -7,8 +7,6 @@ import {
 } from '../../../../database/animals';
 import { getAnimalWithFoods } from '../../../../util/dataStructure';
 
-export const dynamic = 'force-dynamic';
-
 export default async function AnimalPage({ params }) {
   const singleAnimal = await getAnimalById(Number(params.animalId));
   const animalsFoods = await getAnimalsWithFoods(Number(params.animalId));

--- a/app/fruits/[fruitId]/page.tsx
+++ b/app/fruits/[fruitId]/page.tsx
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getFruitById } from '../../../database/fruits';
 import { getCookie } from '../../../util/cookies';
@@ -15,8 +14,6 @@ export type CookieCommentItem = {
 };
 
 export default function FruitPage(props: Props) {
-  const x = headers();
-  x.forEach((a) => console.log(a));
   const fruit = getFruitById(Number(props.params.fruitId));
 
   if (!fruit) {

--- a/app/fruits/[fruitId]/page.tsx
+++ b/app/fruits/[fruitId]/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getFruitById } from '../../../database/fruits';
 import { getCookie } from '../../../util/cookies';
@@ -14,6 +15,8 @@ export type CookieCommentItem = {
 };
 
 export default function FruitPage(props: Props) {
+  const x = headers();
+  x.forEach((a) => console.log(a));
   const fruit = getFruitById(Number(props.params.fruitId));
 
   if (!fruit) {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -34,7 +34,6 @@ export const getAnimals = cache(async () => {
   return [...animals];
 });
 
-
 export const getAnimalsWithLimitAndOffset = cache(
   async (limit: number, offset: number) => {
     const animals = await sql<Animal[]>`
@@ -49,7 +48,6 @@ export const getAnimalsWithLimitAndOffset = cache(
     return animals;
   },
 );
-
 
 export const getAnimalById = cache(async (id: number) => {
   const [animal] = await sql<Animal[]>`

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers';
 import { cache } from 'react';
 import { Animal } from '../migrations/1684915044-createTableAnimals';
 import {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import { cache } from 'react';
 import { Animal } from '../migrations/1684915044-createTableAnimals';
 import {

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -18,13 +18,13 @@ if (!process.env.FLY_IO) config();
 // });
 
 declare module globalThis {
-  let postgresSqlClient: ReturnType<typeof postgres> | undefined;
+  let postgresSqlClient: ReturnType<typeof postgres>;
 }
 
 // Connect only once to the database
 // https://github.com/vercel/next.js/issues/7811#issuecomment-715259370
 function connectOneTimeToDatabase() {
-  if (!globalThis.postgresSqlClient) {
+  if (!('postgresSqlClient' in globalThis)) {
     globalThis.postgresSqlClient = postgres({
       transform: {
         ...postgres.camel,
@@ -37,7 +37,7 @@ function connectOneTimeToDatabase() {
     ...sqlQuery: [TemplateStringsArray, ...ParameterOrFragment<never>[]]
   ) => {
     headers();
-    return globalThis.postgresSqlClient!<PostgresType>(...sqlQuery);
+    return globalThis.postgresSqlClient<PostgresType>(...sqlQuery);
   };
 }
 

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
+import { headers } from 'next/headers';
 import postgres from 'postgres';
 
 // This loads all environment variables from a .env file
@@ -31,8 +32,12 @@ function connectOneTimeToDatabase() {
       },
     });
   }
-  return globalThis.postgresSqlClient;
+
+  return async (strings: TemplateStringsArray, ...values: any) => {
+    headers();
+    return await globalThis.postgresSqlClient!(strings, ...values);
+  };
 }
 
 // Connect to PostgreSQL
-export const sql = connectOneTimeToDatabase();
+export const sql = connectOneTimeToDatabase() as ReturnType<typeof postgres>;

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
+import { headers } from 'next/headers';
 import postgres from 'postgres';
 
 // This loads all environment variables from a .env file
@@ -32,11 +33,11 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return <T extends (object | undefined)[]>(
+  return <PostgresType extends (Record<string, unknown> | undefined)[]>(
     ...sqlQuery: [TemplateStringsArray, ...any[]]
   ) => {
     headers();
-    return globalThis.postgresSqlClient!<T>(...sqlQuery);
+    return globalThis.postgresSqlClient!<PostgresType>(...sqlQuery);
   };
 }
 

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,6 +1,5 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
-import { headers } from 'next/headers';
 import postgres from 'postgres';
 
 // This loads all environment variables from a .env file
@@ -32,12 +31,8 @@ function connectOneTimeToDatabase() {
       },
     });
   }
-
-  return async (strings: TemplateStringsArray, ...values: any) => {
-    headers();
-    return await globalThis.postgresSqlClient!(strings, ...values);
-  };
+  return globalThis.postgresSqlClient;
 }
 
 // Connect to PostgreSQL
-export const sql = connectOneTimeToDatabase() as ReturnType<typeof postgres>;
+export const sql = connectOneTimeToDatabase();

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -33,6 +33,12 @@ function connectOneTimeToDatabase() {
     });
   }
 
+  // Wrap ...
+  //
+  //
+  //
+  //
+  // https://github.com/vercel/next.js/discussions/...
   return ((
     ...sqlParameters: Parameters<typeof globalThis.postgresSqlClient>
   ) => {

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
 import { headers } from 'next/headers';
-import postgres from 'postgres';
+import postgres, { ParameterOrFragment } from 'postgres';
 
 // This loads all environment variables from a .env file
 // for all code after this line
@@ -34,7 +34,7 @@ function connectOneTimeToDatabase() {
   }
 
   return <PostgresType extends (Record<string, unknown> | undefined)[]>(
-    ...sqlQuery: [TemplateStringsArray, ...any[]]
+    ...sqlQuery: [TemplateStringsArray, ...ParameterOrFragment<never>[]]
   ) => {
     headers();
     return globalThis.postgresSqlClient!<PostgresType>(...sqlQuery);

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -33,12 +33,13 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  // Wrap ...
-  //
-  //
-  //
-  //
-  // https://github.com/vercel/next.js/discussions/...
+  // Wrap sql tagged template function to include the headers()function calls before each
+  // database operation
+  // This is necessary for Next.js to treat the page importing the database query
+  // function as a dynamic function, rather than a static one, and allows the correct
+  // handling of the pages during server - side rendering and subsequent dynamic
+  // behavior by Next.js
+  // https://github.com/vercel/next.js/discussions/50695
   return ((
     ...sqlParameters: Parameters<typeof globalThis.postgresSqlClient>
   ) => {

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -33,12 +33,12 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return <PostgresType extends (Record<string, unknown> | undefined)[]>(
-    ...sqlQuery: [TemplateStringsArray, ...ParameterOrFragment<never>[]]
+  return ((
+    ...sqlParameters: Parameters<typeof globalThis.postgresSqlClient>
   ) => {
     headers();
-    return globalThis.postgresSqlClient<PostgresType>(...sqlQuery);
-  };
+    return globalThis.postgresSqlClient(...sqlParameters);
+  }) as typeof globalThis.postgresSqlClient;
 }
 
 // Connect to PostgreSQL

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -33,9 +33,9 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return async (strings: TemplateStringsArray, ...values: any) => {
+  return (...sqlQuery: [TemplateStringsArray, ...any[]]) => {
     headers();
-    return await globalThis.postgresSqlClient!(strings, ...values);
+    return globalThis.postgresSqlClient!(...sqlQuery);
   };
 }
 

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
 import { headers } from 'next/headers';
-import postgres from 'postgres';
+import postgres, { PendingQuery } from 'postgres';
 
 // This loads all environment variables from a .env file
 // for all code after this line
@@ -33,11 +33,13 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  return (...sqlQuery: [TemplateStringsArray, ...any[]]) => {
+  return <T extends (object | undefined)[]>(
+    ...sqlQuery: [TemplateStringsArray, ...any[]]
+  ) => {
     headers();
-    return globalThis.postgresSqlClient!(...sqlQuery);
+    return globalThis.postgresSqlClient!<T>(...sqlQuery);
   };
 }
 
 // Connect to PostgreSQL
-export const sql = connectOneTimeToDatabase() as ReturnType<typeof postgres>;
+export const sql = connectOneTimeToDatabase();

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
 import { headers } from 'next/headers';
-import postgres, { ParameterOrFragment } from 'postgres';
+import postgres, { Sql } from 'postgres';
 
 // This loads all environment variables from a .env file
 // for all code after this line
@@ -18,7 +18,7 @@ if (!process.env.FLY_IO) config();
 // });
 
 declare module globalThis {
-  let postgresSqlClient: ReturnType<typeof postgres>;
+  let postgresSqlClient: Sql;
 }
 
 // Connect only once to the database

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { config } from 'dotenv-safe';
 import { headers } from 'next/headers';
-import postgres, { PendingQuery } from 'postgres';
+import postgres from 'postgres';
 
 // This loads all environment variables from a .env file
 // for all code after this line

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   dotenv-cli:


### PR DESCRIPTION
This PR update the connectOneTimeToDatabase() function in order to call headers() in every call of the sql client. This will prevent Next.js wrongly flag some pages using database queries as static content.

A new https://github.com/vercel/next.js/discussions/50695 to not need to call headers in every sql query

This PR was recreated based on https://github.com/upleveled/next-js-example-spring-2023-vienna-austria/pull/2

merged by mistake